### PR TITLE
Fixes issue #17

### DIFF
--- a/trunk/src/game/g_main.c
+++ b/trunk/src/game/g_main.c
@@ -1329,6 +1329,18 @@ void G_CalculateBuildPoints( void )
         localHTP = 0;
         localATP = 0;
 
+        // Removes all players that haven't spawned
+        for( i = 0; i < MAX_CLIENTS; i++ )
+        {
+          ent = &g_entities[ i ];
+          if(!ent->client || 
+            ent->client->pers.connected != CON_CONNECTED ||
+            ent->client->pers.teamSelection != PTE_HUMANS ||
+            ent->client->sess.sessionTeam != TEAM_SPECTATOR)
+            continue;
+          G_ChangeTeam(ent, PTE_NONE);
+        }
+
         if( g_suddenDeathMode.integer == SDMODE_SELECTIVE )
         {
           for( i = 1, ent = g_entities + i; i < level.num_entities; i++, ent++ )


### PR DESCRIPTION
Issue 17: Checking live players when sd starts
https://github.com/darkgusgus/HungerGames/issues/17

When Hunger Games starts, all human players that haven't spawned are moved to spectate
