### PR TITLE
Fixes Issue #14, Adds tips

### DIFF
--- a/trunk/src/game/g_admin.c
+++ b/trunk/src/game/g_admin.c
@@ -334,6 +334,11 @@ g_admin_cmd_t g_admin_cmds[ ] =
       ""
     },
 
+    {"tips", G_admin_tips, "tips",
+      "shows the server's tips",
+      ""
+    },
+
     {"unban", G_admin_unban, "ban",
       "unbans a player specified by the slot as seen in showbans",
       "[^3ban#^7]"
@@ -861,32 +866,32 @@ static void admin_default_levels( void )
   Q_strncpyz( g_admin_levels[ 0 ]->name, "^4Unknown Player",
     sizeof( l->name ) );
   Q_strncpyz( g_admin_levels[ 0 ]->flags, 
-    "listplayers admintest help specme time", 
+    "listplayers admintest help specme time info tips", 
     sizeof( l->flags ) );
 
   Q_strncpyz( g_admin_levels[ 1 ]->name, "^5Server Regular",
     sizeof( l->name ) );
   Q_strncpyz( g_admin_levels[ 1 ]->flags, 
-    "listplayers admintest help specme time", 
+    "listplayers admintest help specme time info tips", 
     sizeof( l->flags ) );
 
   Q_strncpyz( g_admin_levels[ 2 ]->name, "^6Team Manager",
     sizeof( l->name ) );
   Q_strncpyz( g_admin_levels[ 2 ]->flags, 
-    "listplayers admintest help specme time putteam spec999 warn denybuild",
+    "listplayers admintest help specme time info tips putteam spec999 warn denybuild",
     sizeof( l->flags ) );
 
   Q_strncpyz( g_admin_levels[ 3 ]->name, "^2Junior Admin",
     sizeof( l->name ) );
   Q_strncpyz( g_admin_levels[ 3 ]->flags, 
-    "listplayers admintest help specme time putteam spec999 kick mute warn "
+    "listplayers admintest help specme time info tips putteam spec999 kick mute warn "
     "denybuild ADMINCHAT SEESFULLLISTPLAYERS",
     sizeof( l->flags ) );
 
   Q_strncpyz( g_admin_levels[ 4 ]->name, "^3Senior Admin",
     sizeof( l->name ) );
   Q_strncpyz( g_admin_levels[ 4 ]->flags, 
-    "listplayers admintest help specme time putteam spec999 kick mute showbans "
+    "listplayers admintest help specme time info tips putteam spec999 kick mute showbans "
     "ban namelog warn denybuild ADMINCHAT SEESFULLLISTPLAYERS",
     sizeof( l->flags ) );
 
@@ -1673,6 +1678,9 @@ qboolean G_admin_readconfig( gentity_t *ent, int skiparg )
   qboolean level_open, admin_open, ban_open, command_open;
   int i;
 
+  // Hunger Games Tips
+  G_InitTips( );
+
   G_admin_cleanup();
 
   if( !g_admin.string[ 0 ] )
@@ -1903,8 +1911,8 @@ qboolean G_admin_readconfig( gentity_t *ent, int skiparg )
   if( command_open )
     g_admin_commands[ cc++ ] = c;
   G_Free( cnf2 );
-  ADMP( va( "^3!readconfig: ^7loaded %d levels, %d admins, %d bans, %d commands\n",
-          lc, ac, bc, cc ) );
+  ADMP( va( "^3!readconfig: ^7loaded %d levels, %d admins, %d bans, %d commands, %d tips\n",
+          lc, ac, bc, cc, tipCacheSize ) );
   if( lc == 0 )
     admin_default_levels();
   else
@@ -3525,6 +3533,7 @@ void G_admin_adminlog_log( gentity_t *ent, char *command, char *args, int skipar
       !Q_stricmp( command, "admintest" ) ||
       !Q_stricmp( command, "help" ) ||
       !Q_stricmp( command, "info" ) ||
+      !Q_stricmp( command, "tips" ) ||
       !Q_stricmp( command, "listadmins" ) ||
       !Q_stricmp( command, "listplayers" ) ||
       !Q_stricmp( command, "namelog" ) ||
@@ -7273,6 +7282,15 @@ qboolean G_admin_invisible( gentity_t *ent, int skiparg )
     trap_SendServerCommand( -1, va( "print \"%s" S_COLOR_WHITE " connected\n\"", ent->client->pers.netname ) );
     trap_SendServerCommand( -1, va( "print \"%s" S_COLOR_WHITE " entered the game\n\"", ent->client->pers.netname ) );
   }
+  return qtrue;
+}
+
+qboolean G_admin_tips( gentity_t *ent, int skiparg )
+{
+  int i;
+  ADMP(va("^3!tips: ^7%d tips available.\n", tipCacheSize));
+  for( i = 0; i < tipCacheSize; i++ )
+    ADMP(va("  ^3%d: ^7%s\n", i+1, tipCache[i]));
   return qtrue;
 }
 

--- a/trunk/src/game/g_admin.h
+++ b/trunk/src/game/g_admin.h
@@ -258,6 +258,9 @@ qboolean G_admin_slap( gentity_t *ent, int skiparg );
 qboolean G_admin_drop( gentity_t *ent, int skiparg );
 qboolean G_admin_invisible( gentity_t *ent, int skiparg );
 
+// Hunger Games
+qboolean G_admin_tips( gentity_t *ent, int skiparg );
+
 void G_admin_print( gentity_t *ent, char *m );
 void G_admin_buffer_print( gentity_t *ent, char *m );
 void G_admin_buffer_begin( void );

--- a/trunk/src/game/g_local.h
+++ b/trunk/src/game/g_local.h
@@ -53,6 +53,10 @@ typedef struct gclient_s gclient_t;
 #define FL_NO_HUMANS      0x00004000  // spawn point just for bots
 #define FL_FORCE_GESTURE  0x00008000  // spawn point just for bots
 
+// Hunger Games
+#define HG_MAX_TIP_LENGTH 150 // MAX_SAY_TEXT
+#define HG_MAX_TIP_COUNT 32
+
 typedef struct
 {
   qboolean	isNB;
@@ -1488,6 +1492,13 @@ extern  vmCvar_t  g_aimbotAdvertBanReason;
 // Hunger Games CVars
 extern  vmCvar_t  hg_stage2AdvanceTime;
 extern  vmCvar_t  hg_stage3AdvanceTime;
+
+extern  vmCvar_t  g_tipTime;
+extern  vmCvar_t  g_tipFile;
+extern  vmCvar_t  g_tipPrepend;
+
+extern  char      tipCache[HG_MAX_TIP_COUNT][HG_MAX_TIP_LENGTH + 1];
+extern  int       tipCacheSize;
 
 void      trap_Printf( const char *fmt );
 void      trap_Error( const char *fmt );

--- a/trunk/src/game/g_main.c
+++ b/trunk/src/game/g_main.c
@@ -238,6 +238,19 @@ vmCvar_t  g_aimbotAdvertBanReason;
 vmCvar_t  hg_stage2AdvanceTime;
 vmCvar_t  hg_stage3AdvanceTime;
 
+vmCvar_t  g_tipTime;
+vmCvar_t  g_tipFile;
+vmCvar_t  g_tipPrepend;
+
+
+// Hunger Games
+// Keep these local since they won't be used elsewhere?
+// Another idea is to store in level_locals_t
+int       lastTipTime;
+int       tipIndex;
+char      tipCache[HG_MAX_TIP_COUNT][HG_MAX_TIP_LENGTH + 1];
+int       tipCacheSize;
+
 static cvarTable_t   gameCvarTable[ ] =
 {
   // don't override the cheat state set by the system
@@ -451,7 +464,11 @@ static cvarTable_t   gameCvarTable[ ] =
 
   // Hunger Games CVars
   { &hg_stage2AdvanceTime, "hg_stage2AdvanceTime", "3", CVAR_ARCHIVE, 0, qfalse },
-  { &hg_stage3AdvanceTime, "hg_stage3AdvanceTime", "5", CVAR_ARCHIVE, 0, qfalse }
+  { &hg_stage3AdvanceTime, "hg_stage3AdvanceTime", "5", CVAR_ARCHIVE, 0, qfalse },
+
+  { &g_tipTime, "g_tipTime", "15", CVAR_ARCHIVE, 0, qfalse },
+  { &g_tipFile, "g_tipFile", "info/tips.txt", CVAR_ARCHIVE, 0, qfalse },
+  { &g_tipPrepend, "g_tipPrepend", "^3Tip: ", CVAR_ARCHIVE, 0, qfalse }
 };
 
 static int gameCvarTableSize = sizeof( gameCvarTable ) / sizeof( gameCvarTable[ 0 ] );
@@ -464,6 +481,10 @@ void CheckExitRules( void );
 
 void G_CountSpawns( void );
 void G_CalculateBuildPoints( void );
+
+// Hunger Games
+void G_InitTips( void );
+void G_ShowTips( void );
 
 /*
 ================
@@ -3038,6 +3059,9 @@ void G_RunFrame( int levelTime )
   // for tracking changes
   CheckCvars( );
 
+  // Hunger Games Tips Additions
+  G_ShowTips( );
+
   if( g_listEntity.integer )
   {
     for( i = 0; i < MAX_GENTITIES; i++ )
@@ -3047,3 +3071,89 @@ void G_RunFrame( int levelTime )
   }
 }
 
+void G_InitTips( void )
+{
+  int length, i, j;
+  fileHandle_t infoFile;
+  char message[ MAX_STRING_CHARS ], *cr;
+
+  lastTipTime = level.startTime;
+  tipIndex = 0;
+  tipCacheSize = 0;
+
+  // Most of this pulled from !info
+
+  length = trap_FS_FOpenFile( g_tipFile.string, &infoFile, FS_READ );
+
+  G_LogPrintf(va("Initializing Tip File \"%s\"\n", g_tipFile.string));
+
+  if( length <= 0 || !infoFile )
+  {
+    G_LogPrintf(va("WARNING: Tip File \"%s\" does not exist!\n", g_tipFile.string));
+    return;
+  }
+  
+  // Read from file
+  trap_FS_Read( message, sizeof( message ), infoFile );
+
+  if( length < sizeof( message ) )
+    message[ length ] = '\0';
+  else
+    message[ sizeof( message ) - 1 ] = '\0';
+  
+  trap_FS_FCloseFile( infoFile );
+
+  // Strip \r's
+  while( ( cr = strchr( message, '\r' ) ) )
+    memmove( cr, cr + 1, strlen( cr + 1 ) + 1 );
+
+  i = 0;
+  j = 0;
+  for(cr = message; *cr && cr - message < length; cr++, j++)
+  {
+    if(*cr == '\n' || j >= HG_MAX_TIP_LENGTH)
+    {
+      if(j >= HG_MAX_TIP_LENGTH)
+      {
+        G_LogPrintf("WARNING: Tip \"%s\" exceeds maximum tip length.\n", tipCache[i]);
+        while(*cr != '\n' && *cr != '\0')
+          cr++;
+        if(!*cr)
+          break;
+      }
+
+      if( ++i >= HG_MAX_TIP_COUNT )
+      {
+        G_LogPrintf("WARNING: Tip File \"%s\" exceeds maximum tip count.\n", g_tipFile.string);
+        break;
+      }
+      else
+      {
+        tipCache[i][j] = '\0'; // null terminate
+        j = -1; // j++ in for loop
+        continue;
+      }
+    }
+    tipCache[i][j] = *cr;
+  }
+  tipCacheSize = i;
+}
+
+/*
+================
+G_ShowTips
+
+Part of Hunger Games
+Shows a tip every g_tipTime
+================
+*/
+void G_ShowTips( void )
+{
+  if(tipCacheSize <= 0 || (level.time - lastTipTime) < g_tipTime.integer * 1000)
+    return;
+  if(tipIndex >= tipCacheSize)
+    tipIndex = 0;
+  trap_SendServerCommand( -1, va( "print \"%s^7%s\n\"", g_tipPrepend.string, tipCache[tipIndex] ) );
+  lastTipTime = level.time;
+  tipIndex++;
+}

--- a/trunk/src/game/g_main.c
+++ b/trunk/src/game/g_main.c
@@ -3085,11 +3085,16 @@ void G_InitTips( void )
 
   length = trap_FS_FOpenFile( g_tipFile.string, &infoFile, FS_READ );
 
-  G_LogPrintf(va("Initializing Tip File \"%s\"\n", g_tipFile.string));
+  G_LogPrintf( "Initializing Tip File \"%s\"\n", g_tipFile.string );
 
-  if( length <= 0 || !infoFile )
+  if( length < 0 || !infoFile )
   {
-    G_LogPrintf(va("WARNING: Tip File \"%s\" does not exist!\n", g_tipFile.string));
+    G_LogPrintf( "WARNING: Tip File \"%s\" does not exist!\n", g_tipFile.string );
+    return;
+  }
+  if( length == 0 )
+  {
+    G_LogPrintf( "WARNING: Tip File \"%s\" contains no tips!\n", g_tipFile.string );
     return;
   }
   


### PR DESCRIPTION
Issue #14: Tips

Adds the following cvars:
g_tipTime - Time between each tip in seconds (default: 15)
g_tipFile - File to read tips from (default: "info/tips.txt")
g_tipPrepend - Prepended string to tips (default: "^3Tip: ")

Adds the following admin commands:
!tips - lists all available tips (flag: "tips")

NOTE: Added tips to default admin config

Tips are cached, they may be reloaded via !readconfig

Max tips: 32 (HG_MAX_TIP_COUNT in g_local.h:57)
Max tip length: 150 (HG_MAX_TIP_LENGTH in g_local.h:58)
