### PR TITLE
Removes Sudden Death, adds delayed start to Hunger Games

### DIFF
--- a/src/game/g_buildable.c
+++ b/src/game/g_buildable.c
@@ -850,7 +850,7 @@ void AOvermind_Think( gentity_t *self )
         }
       }
       // aliens now know they have no eggs, but they're screwed, so stfu
-      if( !haveBuilder || G_TimeTilSuddenDeath( ) <= 0 )
+      if( !haveBuilder || G_TimeTilHungerGames( ) <= 0 )
         level.overmindMuted = qtrue;
     }
 

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -801,7 +801,7 @@ void Cmd_Team_f( gentity_t *ent )
       return;
     }
 
-    if( ( level.alienTeamLocked || g_suddenDeath.integer ) && !force )
+    if( ( level.alienTeamLocked || g_hungerGames.integer ) && !force )
     {
       trap_SendServerCommand( ent-g_entities,
         va( "print \"Alien team has been ^1LOCKED\n\"" ) );
@@ -831,7 +831,7 @@ void Cmd_Team_f( gentity_t *ent )
       return;
     }
 
-    if( ( level.humanTeamLocked || g_suddenDeath.integer ) && !force )
+    if( ( level.humanTeamLocked || g_hungerGames.integer ) && !force )
     {
       trap_SendServerCommand( ent-g_entities,
         va( "print \"Human team has been ^1LOCKED\n\"" ) );
@@ -854,7 +854,7 @@ void Cmd_Team_f( gentity_t *ent )
   }
   else if( !Q_stricmp( s, "auto" ) )
   {
-    if( g_suddenDeath.integer || ( level.humanTeamLocked && level.alienTeamLocked ) )
+    if( g_hungerGames.integer || ( level.humanTeamLocked && level.alienTeamLocked ) )
       team = PTE_NONE;
     else if( humans > aliens )
       team = PTE_ALIENS;
@@ -1805,33 +1805,33 @@ void Cmd_CallVote_f( gentity_t *ent )
       Com_sprintf( level.voteDisplayString,
           sizeof( level.voteDisplayString ), "[Poll] \'%s\'", arg2plus );
    }
-   else if( !Q_stricmp( arg1, "sudden_death" ) ||
-     !Q_stricmp( arg1, "suddendeath" ) )
+   else if( !Q_stricmp( arg1, "hunger_games" ) ||
+     !Q_stricmp( arg1, "hungergames" ) )
    {
-     if(!g_suddenDeathVotePercent.integer)
+     if(!g_hungerGamesVotePercent.integer)
      {
        trap_SendServerCommand( ent-g_entities, "print \"Sudden Death votes have been disabled\n\"" );
        return;
      } 
-     else if( g_suddenDeath.integer ) 
+     else if( g_hungerGames.integer ) 
      {
       trap_SendServerCommand( ent - g_entities, va( "print \"callvote: Sudden Death has already begun\n\"") );
       return;
      }
-     else if( G_TimeTilSuddenDeath() <= g_suddenDeathVoteDelay.integer * 1000 )
+     else if( G_TimeTilHungerGames() <= g_hungerGamesVoteDelay.integer * 1000 )
      {
       trap_SendServerCommand( ent - g_entities, va( "print \"callvote: Sudden Death is already immenent\n\"") );
       return;
      }
     else 
      {
-       level.votePassThreshold = g_suddenDeathVotePercent.integer;
-       Com_sprintf( level.voteString, sizeof( level.voteString ), "suddendeath" );
+       level.votePassThreshold = g_hungerGamesVotePercent.integer;
+       Com_sprintf( level.voteString, sizeof( level.voteString ), "hungergames" );
        Com_sprintf( level.voteDisplayString,
            sizeof( level.voteDisplayString ), "Begin sudden death" );
 
-       if( g_suddenDeathVoteDelay.integer )
-         Q_strcat( level.voteDisplayString, sizeof( level.voteDisplayString ), va( " in %d seconds", g_suddenDeathVoteDelay.integer ) );
+       if( g_hungerGamesVoteDelay.integer )
+         Q_strcat( level.voteDisplayString, sizeof( level.voteDisplayString ), va( " in %d seconds", g_hungerGamesVoteDelay.integer ) );
 
      }
    }
@@ -1959,7 +1959,7 @@ void Cmd_CallVote_f( gentity_t *ent )
     {
       trap_SendServerCommand( ent-g_entities, "print \"Invalid vote string\n\"" );
       trap_SendServerCommand( ent-g_entities, "print \"Valid vote commands are: "
-        "map, map_restart, draw, extend, nextmap, kick, spec, mute, unmute, poll, and sudden_death\n" );
+        "map, map_restart, draw, extend, nextmap, kick, spec, mute, unmute, poll, and hunger_games\n" );
       if( customVoteKeys[ 0 ] != '\0' )
         trap_SendServerCommand( ent-g_entities,
           va( "print \"Additional custom vote commands: %s\n\"", customVoteKeys ) );
@@ -3007,13 +3007,13 @@ void Cmd_Destroy_f( gentity_t *ent )
         return;
 
       // Don't allow destruction of buildables that cannot be rebuilt
-      if(!g_cheats.integer && g_suddenDeath.integer && traceEnt->health > 0 &&
-          ( ( g_suddenDeathMode.integer == SDMODE_SELECTIVE &&
+      if(!g_cheats.integer && g_hungerGames.integer && traceEnt->health > 0 &&
+          ( ( g_hungerGamesMode.integer == SDMODE_SELECTIVE &&
               !BG_FindReplaceableTestForBuildable( traceEnt->s.modelindex ) ) ||
-            ( g_suddenDeathMode.integer == SDMODE_BP &&
+            ( g_hungerGamesMode.integer == SDMODE_BP &&
               BG_FindBuildPointsForBuildable( traceEnt->s.modelindex ) ) ||
-            g_suddenDeathMode.integer == SDMODE_NO_BUILD  ||
-            g_suddenDeathMode.integer == SDMODE_NO_DECON ) )
+            g_hungerGamesMode.integer == SDMODE_NO_BUILD  ||
+            g_hungerGamesMode.integer == SDMODE_NO_DECON ) )
       {
         trap_SendServerCommand( ent-g_entities,
           "print \"During Sudden Death you can only decon buildings that "
@@ -3147,13 +3147,13 @@ void Cmd_Mark_f( gentity_t *ent )
       }
 
       // Don't allow marking of buildables that cannot be rebuilt
-      if(!g_cheats.integer && g_suddenDeath.integer && traceEnt->health > 0 &&
-          ( ( g_suddenDeathMode.integer == SDMODE_SELECTIVE &&
+      if(!g_cheats.integer && g_hungerGames.integer && traceEnt->health > 0 &&
+          ( ( g_hungerGamesMode.integer == SDMODE_SELECTIVE &&
               !BG_FindReplaceableTestForBuildable( traceEnt->s.modelindex ) ) ||
-            ( g_suddenDeathMode.integer == SDMODE_BP &&
+            ( g_hungerGamesMode.integer == SDMODE_BP &&
               BG_FindBuildPointsForBuildable( traceEnt->s.modelindex ) ) ||
-            g_suddenDeathMode.integer == SDMODE_NO_BUILD ||
-            g_suddenDeathMode.integer == SDMODE_NO_DECON ) )
+            g_hungerGamesMode.integer == SDMODE_NO_BUILD ||
+            g_hungerGamesMode.integer == SDMODE_NO_DECON ) )
       {
         trap_SendServerCommand( ent-g_entities,
           "print \"During Sudden Death you can only mark buildings that "
@@ -3685,9 +3685,9 @@ void Cmd_Build_f( gentity_t *ent )
   buildable = BG_FindBuildNumForName( s );
 
 
-  if( g_suddenDeath.integer && !g_cheats.integer )
+  if( g_hungerGames.integer && !g_cheats.integer )
   {
-    if( g_suddenDeathMode.integer == SDMODE_SELECTIVE )
+    if( g_hungerGamesMode.integer == SDMODE_SELECTIVE )
     {
       if( !BG_FindReplaceableTestForBuildable( buildable ) )
       {
@@ -3702,7 +3702,7 @@ void Cmd_Build_f( gentity_t *ent )
         return;
       }
     }
-    else if( g_suddenDeathMode.integer == SDMODE_NO_BUILD )
+    else if( g_hungerGamesMode.integer == SDMODE_NO_BUILD )
     {
       trap_SendServerCommand( ent-g_entities,
         "print \"Building is not allowed during Sudden Death\n\"" );

--- a/src/game/g_cmds.c
+++ b/src/game/g_cmds.c
@@ -1810,17 +1810,17 @@ void Cmd_CallVote_f( gentity_t *ent )
    {
      if(!g_hungerGamesVotePercent.integer)
      {
-       trap_SendServerCommand( ent-g_entities, "print \"Sudden Death votes have been disabled\n\"" );
+       trap_SendServerCommand( ent-g_entities, "print \"Hunger Games votes have been disabled\n\"" );
        return;
      } 
      else if( g_hungerGames.integer ) 
      {
-      trap_SendServerCommand( ent - g_entities, va( "print \"callvote: Sudden Death has already begun\n\"") );
+      trap_SendServerCommand( ent - g_entities, va( "print \"callvote: Hunger Games has already begun\n\"") );
       return;
      }
      else if( G_TimeTilHungerGames() <= g_hungerGamesVoteDelay.integer * 1000 )
      {
-      trap_SendServerCommand( ent - g_entities, va( "print \"callvote: Sudden Death is already immenent\n\"") );
+      trap_SendServerCommand( ent - g_entities, va( "print \"callvote: Hunger Games is already immenent\n\"") );
       return;
      }
     else 
@@ -1828,7 +1828,7 @@ void Cmd_CallVote_f( gentity_t *ent )
        level.votePassThreshold = g_hungerGamesVotePercent.integer;
        Com_sprintf( level.voteString, sizeof( level.voteString ), "hungergames" );
        Com_sprintf( level.voteDisplayString,
-           sizeof( level.voteDisplayString ), "Begin sudden death" );
+           sizeof( level.voteDisplayString ), "Begin hunger games" );
 
        if( g_hungerGamesVoteDelay.integer )
          Q_strcat( level.voteDisplayString, sizeof( level.voteDisplayString ), va( " in %d seconds", g_hungerGamesVoteDelay.integer ) );
@@ -3016,7 +3016,7 @@ void Cmd_Destroy_f( gentity_t *ent )
             g_hungerGamesMode.integer == SDMODE_NO_DECON ) )
       {
         trap_SendServerCommand( ent-g_entities,
-          "print \"During Sudden Death you can only decon buildings that "
+          "print \"During Hunger Games you can only decon buildings that "
           "can be rebuilt\n\"" );
         return;
       }
@@ -3156,7 +3156,7 @@ void Cmd_Mark_f( gentity_t *ent )
             g_hungerGamesMode.integer == SDMODE_NO_DECON ) )
       {
         trap_SendServerCommand( ent-g_entities,
-          "print \"During Sudden Death you can only mark buildings that "
+          "print \"During Hunger Games you can only mark buildings that "
           "can be rebuilt\n\"" );
         return;
       }
@@ -3692,20 +3692,20 @@ void Cmd_Build_f( gentity_t *ent )
       if( !BG_FindReplaceableTestForBuildable( buildable ) )
       {
         trap_SendServerCommand( ent-g_entities,
-          "print \"This building type cannot be rebuilt during Sudden Death\n\"" );
+          "print \"This building type cannot be rebuilt during Hunger Games\n\"" );
         return;
       }
       if( G_BuildingExists( buildable ) )
       {
         trap_SendServerCommand( ent-g_entities,
-          "print \"You can only rebuild one of each type of rebuildable building during Sudden Death.\n\"" );
+          "print \"You can only rebuild one of each type of rebuildable building during Hunger Games.\n\"" );
         return;
       }
     }
     else if( g_hungerGamesMode.integer == SDMODE_NO_BUILD )
     {
       trap_SendServerCommand( ent-g_entities,
-        "print \"Building is not allowed during Sudden Death\n\"" );
+        "print \"Building is not allowed during Hunger Games\n\"" );
       return;
     }
   }

--- a/src/game/g_combat.c
+++ b/src/game/g_combat.c
@@ -1334,7 +1334,7 @@ void G_Damage( gentity_t *targ, gentity_t *inflictor, gentity_t *attacker,
       return;
 
     // HG invincibility
-    if( targ->s.eType != ET_BUILDABLE && !g_suddenDeath.integer )
+    if( targ->s.eType != ET_BUILDABLE && !g_hungerGames.integer )
       return;
 
     if( level.paused )

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -765,11 +765,11 @@ typedef struct
 
   pTeam_t           lastWin;
 
-  int               suddenDeathABuildPoints;
-  int               suddenDeathHBuildPoints;
-  qboolean          suddenDeath;
-  int               suddenDeathBeginTime;
-  timeWarning_t     suddenDeathWarning;
+  int               hungerGamesABuildPoints;
+  int               hungerGamesHBuildPoints;
+  qboolean          hungerGames;
+  int               hungerGamesBeginTime;
+  timeWarning_t     hungerGamesWarning;
   timeWarning_t     timelimitWarning;
   int               extend_vote_count;
 
@@ -1145,7 +1145,7 @@ void QDECL G_Error( const char *fmt, ... );
 void CheckVote( void );
 void CheckTeamVote( int teamnum );
 void LogExit( const char *string );
-int  G_TimeTilSuddenDeath( void );
+int  G_TimeTilHungerGames( void );
 void CheckMsgTimer( void );
 qboolean G_Flood_Limited( gentity_t *ent );
 
@@ -1315,9 +1315,9 @@ extern  vmCvar_t  g_newbieNumbering;
 extern  vmCvar_t  g_newbieNamePrefix;
 
 extern  vmCvar_t  g_timelimit;
-extern  vmCvar_t  g_suddenDeathTime;
-extern  vmCvar_t  g_suddenDeath;
-extern  vmCvar_t  g_suddenDeathMode;
+extern  vmCvar_t  g_hungerGamesTime;
+extern  vmCvar_t  g_hungerGames;
+extern  vmCvar_t  g_hungerGamesMode;
 extern  vmCvar_t  g_friendlyFire;
 extern  vmCvar_t  g_friendlyFireHumans;
 extern  vmCvar_t  g_friendlyFireAliens;
@@ -1345,8 +1345,8 @@ extern  vmCvar_t  g_blood;
 extern  vmCvar_t  g_allowVote;
 extern  vmCvar_t  g_requireVoteReasons;
 extern  vmCvar_t  g_voteLimit;
-extern  vmCvar_t  g_suddenDeathVotePercent;
-extern  vmCvar_t  g_suddenDeathVoteDelay;
+extern  vmCvar_t  g_hungerGamesVotePercent;
+extern  vmCvar_t  g_hungerGamesVoteDelay;
 extern  vmCvar_t  g_extendVotesPercent;
 extern  vmCvar_t  g_extendVotesTime;
 extern  vmCvar_t  g_extendVotesCount;

--- a/src/game/g_local.h
+++ b/src/game/g_local.h
@@ -819,6 +819,8 @@ typedef struct
   nbMarkers_t	    nbMarkers[ MAX_GENTITIES ];
 
   gclient_t         *lastHumanClient;
+  int               hungerGamesReadyTime;
+  qboolean          hungerGamesStarted;
 } level_locals_t;
 
 #define CMD_CHEAT         0x01
@@ -1492,6 +1494,7 @@ extern  vmCvar_t  g_aimbotAdvertBanReason;
 // Hunger Games CVars
 extern  vmCvar_t  hg_stage2AdvanceTime;
 extern  vmCvar_t  hg_stage3AdvanceTime;
+extern  vmCvar_t  hg_minPlayers;
 
 extern  vmCvar_t  g_tipTime;
 extern  vmCvar_t  g_tipFile;

--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -1364,13 +1364,13 @@ void G_CalculateBuildPoints( void )
   {
     if(g_hungerGames.integer || G_TimeTilHungerGames( ) <= 0 ) //Conditions to enter SD
     {
-      //begin sudden death
+      //begin hunger games
       if( level.hungerGamesWarning < TW_PASSED )
       {
         trap_SendServerCommand( -1, "cp \"The Hunger games have begun!\"" );
         if( !g_cheats.integer )
           trap_SendConsoleCommand( EXEC_NOW, "alienWin\n" );
-        G_LogPrintf("Beginning Sudden Death (Mode %d)\n",g_hungerGamesMode.integer);
+        G_LogPrintf("Beginning Hunger Games (Mode %d)\n",g_hungerGamesMode.integer);
         localHTP = 0;
         localATP = 0;
 
@@ -1415,7 +1415,7 @@ void G_CalculateBuildPoints( void )
     }  
     else 
     {
-       //warn about sudden death
+       //warn about hunger games
        if( ( G_TimeTilHungerGames( ) <= 60000 ) &&
            (  level.hungerGamesWarning < TW_IMMINENT ) )
        {
@@ -2585,7 +2585,7 @@ void CheckVote( void )
       level.voteString[0] = '\0';
 
       if( g_hungerGamesVoteDelay.integer )
-        trap_SendServerCommand( -1, va("cp \"Sudden Death will begin in %d seconds\n\"", g_hungerGamesVoteDelay.integer  ) );
+        trap_SendServerCommand( -1, va("cp \"Hunger Games will begin in %d seconds\n\"", g_hungerGamesVoteDelay.integer  ) );
     }
 
     if( level.voteString[0] )

--- a/src/game/g_spawn.c
+++ b/src/game/g_spawn.c
@@ -607,7 +607,7 @@ void SP_worldspawn( void )
   // make some data visible to connecting client
   trap_SetConfigstring( CS_GAME_VERSION, GAME_VERSION );
 
-  trap_SetConfigstring( CS_LEVEL_START_TIME, va( "%i", level.startTime ) );
+  trap_SetConfigstring( CS_LEVEL_START_TIME, va( "%i", level.hungerGamesReadyTime ) );
 
   G_SpawnString( "music", "", &s );
   trap_SetConfigstring( CS_MUSIC, s );

--- a/src/game/tremulous.h
+++ b/src/game/tremulous.h
@@ -619,7 +619,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define DAMAGE_FRACTION_FOR_KILL    0.5f //how much damage players (versus structures) need to
                                          //do to increment the stage kill counters
 
-// g_suddenDeathMode settings
+// g_hungerGamesMode settings
 #define SDMODE_BP                   0
 #define SDMODE_NO_BUILD             1
 #define SDMODE_SELECTIVE            2

--- a/src/ui/ui_gameinfo.c
+++ b/src/ui/ui_gameinfo.c
@@ -318,7 +318,7 @@ void UI_ServerInfo( void )
     trap_Cvar_Set( "ui_serverinfo_timelimit",
       Info_ValueForKey( info, "timelimit" ) );
     trap_Cvar_Set( "ui_serverinfo_sd",
-      Info_ValueForKey( info, "g_suddenDeathTime" ) );
+      Info_ValueForKey( info, "g_hungerGamesTime" ) );
     trap_Cvar_Set( "ui_serverinfo_hostname",
       Info_ValueForKey( info, "sv_hostname" ) );
     trap_Cvar_Set( "ui_serverinfo_maxclients",

--- a/ui/ingame_game.menu
+++ b/ui/ingame_game.menu
@@ -167,7 +167,7 @@
       rect 30 85 256 20
       type 4
       style 0	
-      text "Sudden Death Time:"
+      text "Hunger Games Time:"
       cvar ui_serverinfo_sd
       maxPaintChars 12
       textalign ITEM_ALIGN_RIGHT
@@ -969,7 +969,7 @@
       rect 30 85 256 20
       type 4
       style 0	
-      text "Sudden Death Time:"
+      text "Hunger Games Time:"
       cvar ui_serverinfo_sd
       maxPaintChars 12
       textalign ITEM_ALIGN_RIGHT
@@ -1770,7 +1770,7 @@
       rect 30 85 256 20
       type 4
       style 0	
-      text "Sudden Death Time:"
+      text "Hunger Games Time:"
       cvar ui_serverinfo_sd
       maxPaintChars 12
       textalign ITEM_ALIGN_RIGHT
@@ -2571,7 +2571,7 @@
       rect 30 85 256 20
       type 4
       style 0	
-      text "Sudden Death Time:"
+      text "Hunger Games Time:"
       cvar ui_serverinfo_sd
       maxPaintChars 12
       textalign ITEM_ALIGN_RIGHT		


### PR DESCRIPTION
Replaced all references of Sudden Death to Hunger games
(Sudden Death was used as the trigger to start Hunger Games)

Added hg_minPlayers
- Waits until hg_minPlayers are alive before starting the countdown

Resolves #16 
